### PR TITLE
fix: invalid hyperevmscan

### DIFF
--- a/src/client/hooks/use-detailed-token-info.ts
+++ b/src/client/hooks/use-detailed-token-info.ts
@@ -214,7 +214,7 @@ export const getTokenExplorerUrl = (
   // For ERC20 tokens, return normal token contract URLs
   switch (chain) {
     case 'hyperevm':
-      return `https://hyperevmscan.com/token/${contractAddress}`;
+      return `https://hyperevmscan.io/token/${contractAddress}`;
     case 'ethereum':
       return `https://etherscan.io/token/${contractAddress}`;
     case 'base':


### PR DESCRIPTION
Original url

https://hyperevmscan.com/token/0x713f4c66221c3920578675DFc45cFA71B5F1f307

The actually working one 

https://hyperevmscan.io/token/0x713f4c66221c3920578675DFc45cFA71B5F1f307
